### PR TITLE
add sidebar resizing support

### DIFF
--- a/src/lib/kit/layout/Sidebar.svelte
+++ b/src/lib/kit/layout/Sidebar.svelte
@@ -25,12 +25,16 @@
 
 	.sidebar {
 		height: 100%;
+		min-width: 320px;
 		width: 320px;
+		max-width: 720px;
 		display: flex;
 		flex-direction: column;
 		opacity: var(--o);
 		scale: var(--u);
-		transition: 0.25s;
+		// transition: 0.25s;
 		transform: rotate3d(0, var(--r), 0, 90deg);
+		overflow: hidden;
+		resize: horizontal;
 	}
 </style>

--- a/src/lib/kit/layout/Sidebar.svelte
+++ b/src/lib/kit/layout/Sidebar.svelte
@@ -32,7 +32,9 @@
 		flex-direction: column;
 		opacity: var(--o);
 		scale: var(--u);
+		.bar {
 		transition: 0.25s;
+		}
 		transform: rotate3d(0, var(--r), 0, 90deg);
 		overflow: hidden;
 		resize: horizontal;

--- a/src/lib/kit/layout/Sidebar.svelte
+++ b/src/lib/kit/layout/Sidebar.svelte
@@ -32,7 +32,7 @@
 		flex-direction: column;
 		opacity: var(--o);
 		scale: var(--u);
-		// transition: 0.25s;
+		transition: 0.25s;
 		transform: rotate3d(0, var(--r), 0, 90deg);
 		overflow: hidden;
 		resize: horizontal;

--- a/src/lib/kit/layout/sidebarElems/ChatEntriesContainer.svelte
+++ b/src/lib/kit/layout/sidebarElems/ChatEntriesContainer.svelte
@@ -26,7 +26,7 @@
 	@use '$lib/style/variables.scss' as v;
 
 	.chatEntriesContainer {
-		width: 320px;
+		width: 100%;
 		height: 100%;
 	}
 

--- a/src/lib/kit/layout/sidebarElems/SidebarTop.svelte
+++ b/src/lib/kit/layout/sidebarElems/SidebarTop.svelte
@@ -34,7 +34,7 @@
 	<div
 		class="elements-horiz"
 		style="
-        width: 300px;
+        width: calc(100% - 20px);
         justify-content: space-between; 
         padding-right: 10px; 
         padding-left: 10px;"


### PR DESCRIPTION
kinda broken with userbar, needs fixing
this is held together by the [resize](developer.mozilla.org/en-US/docs/Web/CSS/resize) css property
also removes the `transition: 0.25s;` on the sidebar (what was that even used for?)
a better solution would be to create a dedicated handle and do some typescripting, but i do not type script (get it)

im going insane please help me dear god